### PR TITLE
Updated item retrieval from index 0 to 1

### DIFF
--- a/src/main/java/com/golem/skyblockutils/models/AttributePrice.java
+++ b/src/main/java/com/golem/skyblockutils/models/AttributePrice.java
@@ -330,7 +330,7 @@ public class AttributePrice {
 				if (min_tier > 0) {
 					value = items.get(min_tier) << attr_tier;
 				} else {
-					value = items.get(0) << attr_tier;
+					value = items.get(1) << attr_tier;
 				}
 				added_value += value;
 				total_tiers += 1 << attr_tier;


### PR DESCRIPTION
All armours and equipment always set to salvagable if minimum tier is set to 0.